### PR TITLE
Add `@key` support inside #each blocks for hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support for @root object
+* Support for @key object inside #each blocks with Hashes
+
+### Fixed
+
+* Hashes now work with #each blocks
 
 ## [1.0.0] - 2022-01-19
 

--- a/lib/flavour_saver/helpers.rb
+++ b/lib/flavour_saver/helpers.rb
@@ -11,14 +11,15 @@ module FlavourSaver
         r = []
         count = 0
         collection.each do |element|
-          r << yield.contents(
-            element,
-            {
-              'index' => count,
-              'last' => count == collection.size - 1,
-              'first' => count == 0
-            }
-          )
+          locals ={
+            'index' => count,
+            'last' => count == collection.size - 1,
+            'first' => count == 0
+          }
+
+          locals['key'], element = element if collection.is_a?(Hash)
+
+          r << yield.contents(element, locals)
           count += 1
         end
         yield.rendered!
@@ -111,10 +112,10 @@ module FlavourSaver
 
     def decorate_with(context, helper_names=[], locals={})
       helpers = if helper_names.any?
-                  helper_names = helper_names.map(&:to_sym)
-                  registered_helpers.select { |k,v| helper_names.member? k }.merge(locals)
+                  helper_symbols = helper_names.map(&:to_sym)
+                  registered_helpers.select { |k,v| helper_symbols.member? k }
                 else
-                  helpers = registered_helpers
+                  registered_helpers
                 end
       helpers = helpers.merge(locals)
       Decorator.new(helpers, context)

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -964,6 +964,36 @@ describe FlavourSaver do
       end
     end
 
+    describe 'each with @key' do
+      let(:template) { "{{#each goodbyes}}{{@key}}. {{text}}! {{/each}}cruel {{world}}!" }
+
+      example 'the @key variable is used' do
+        g = Struct.new(:text)
+        allow(context).to receive(:goodbyes).and_return({
+          one: g.new('goodbye'),
+          two: g.new('Goodbye'),
+          three: g.new('GOODBYE')
+        })
+        allow(context).to receive(:world).and_return('world')
+        expect(subject).to eq "one. goodbye! two. Goodbye! three. GOODBYE! cruel world!"
+      end
+    end
+
+    describe 'each with @key in a nested block' do
+      let(:template) { "{{#each goodbyes}}{{#if @last}}{{@key}}. {{/if}}{{text}}! {{/each}}cruel {{world}}!" }
+
+      example 'the @key variable is used' do
+        g = Struct.new(:text)
+        allow(context).to receive(:goodbyes).and_return({
+          one: g.new('goodbye'),
+          two: g.new('Goodbye'),
+          three: g.new('GOODBYE')
+        })
+        allow(context).to receive(:world).and_return('world')
+        expect(subject).to eq "goodbye! Goodbye! three. GOODBYE! cruel world!"
+      end
+    end
+
     describe 'log' do
       let(:template) { "{{log blah}}" }
       let(:log) { double(:log) }


### PR DESCRIPTION
This also has the nice side effect of fixing 'this' inside each blocks for hashes. Previously, 'this' would be an array of [key, value]. Now the value of 'this' is the value and @key corresponds to the key.

Closes #17.