### PR TITLE
Make zero on conditions be falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Support for @root object
 
+### Fixed
+
+* Zero is now falsy in if/else conditions as it is in Handlebars.js
+
 ## [1.0.0] - 2022-01-19
 
 ### Added

--- a/lib/flavour_saver/helpers.rb
+++ b/lib/flavour_saver/helpers.rb
@@ -27,7 +27,7 @@ module FlavourSaver
 
       def if(truthy)
         truthy = false if truthy.respond_to?(:size) && (truthy.size == 0)
-        truthy = false if truthy == 0
+        truthy = false if truthy.respond_to?(:zero?) && truthy.zero?
 
         if truthy
           yield.contents

--- a/lib/flavour_saver/helpers.rb
+++ b/lib/flavour_saver/helpers.rb
@@ -27,6 +27,8 @@ module FlavourSaver
 
       def if(truthy)
         truthy = false if truthy.respond_to?(:size) && (truthy.size == 0)
+        truthy = false if truthy == 0
+
         if truthy
           yield.contents
         else

--- a/spec/acceptance/if_else_spec.rb
+++ b/spec/acceptance/if_else_spec.rb
@@ -16,9 +16,19 @@ describe 'Fixture: if_else.hbs' do
     expect(subject).to eq "The given value is truthy: 1."
   end
 
-  it "renders the else block when given a zero" do
-    context.value = 0
-    expect(subject).to eq "The given value is falsy: 0."
+  it "renders the if block when given an array that is not empty" do
+    context.value = [1]
+    expect(subject).to eq "The given value is truthy: [1]."
+  end
+
+  it "renders the else block when given false" do
+    context.value = false
+    expect(subject).to eq "The given value is falsy: false."
+  end
+
+  it 'renders the else block when given nil' do
+    context.value = nil
+    expect(subject).to eq "The given value is falsy: ."
   end
 
   it "renders the else block when given an empty string" do
@@ -26,7 +36,13 @@ describe 'Fixture: if_else.hbs' do
     expect(subject).to eq "The given value is falsy: ."
   end
 
-  it 'renders the else block when given nil' do
-    expect(subject).to eq "The given value is falsy: ."
+  it "renders the else block when given a zero" do
+    context.value = 0
+    expect(subject).to eq "The given value is falsy: 0."
+  end
+
+  it "renders the else block when given an empty array" do
+    context.value = []
+    expect(subject).to eq "The given value is falsy: []."
   end
 end

--- a/spec/acceptance/if_else_spec.rb
+++ b/spec/acceptance/if_else_spec.rb
@@ -3,15 +3,30 @@ require 'flavour_saver'
 
 describe 'Fixture: if_else.hbs' do
   subject { Tilt.new(template).render(context).gsub(/[\s\r\n]+/, ' ').strip }
-  let(:context) { Struct.new(:name).new }
+  let(:context) { Struct.new(:value).new }
   let(:template) { File.expand_path('../../fixtures/if_else.hbs', __FILE__) }
 
-  it 'renders correctly when given a name' do
-    context.name = 'Alan'
-    expect(subject).to eq "Say hello to Alan."
+  it "renders the if block when given a string" do
+    context.value = "Alan"
+    expect(subject).to eq "The given value is truthy: Alan."
   end
 
-  it 'renders correctly when not given a name' do
-    expect(subject).to eq "Nobody to say hi to."
+  it "renders the if block when given a number greater than zero" do
+    context.value = 1
+    expect(subject).to eq "The given value is truthy: 1."
+  end
+
+  it "renders the else block when given a zero" do
+    context.value = 0
+    expect(subject).to eq "The given value is falsy: 0."
+  end
+
+  it "renders the else block when given an empty string" do
+    context.value = ""
+    expect(subject).to eq "The given value is falsy: ."
+  end
+
+  it 'renders the else block when given nil' do
+    expect(subject).to eq "The given value is falsy: ."
   end
 end

--- a/spec/fixtures/if_else.hbs
+++ b/spec/fixtures/if_else.hbs
@@ -1,5 +1,5 @@
-{{#if name}}
-  Say hello to {{name}}.
+{{#if value}}
+  The given value is truthy: {{value}}.
   {{else}}
-  Nobody to say hi to.
+  The given value is falsy: {{value}}.
 {{/if}}


### PR DESCRIPTION
This is needed to fix an unintentional divergence between templates
rendered in ruby and in javascript.

This should fix #38