### PR TITLE
Fix behaviour of unless to be inverse of if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Zero is now falsy in if/else conditions as it is in Handlebars.js
 * Lex number literals that start with 0
 * Hashes now work with #each blocks
-* Zero is now truthy in unless conditions as it is in Handlebars.js
+* Zero and empty objects are evaluated in unless helper as they are in Handlebars.js
 
 ## [1.0.0] - 2022-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Zero is now falsy in if/else conditions as it is in Handlebars.js
 * Lex number literals that start with 0
 * Hashes now work with #each blocks
+* Zero is now truthy in unless conditions as it is in Handlebars.js
 
 ## [1.0.0] - 2022-01-19
 

--- a/lib/flavour_saver/helpers.rb
+++ b/lib/flavour_saver/helpers.rb
@@ -26,19 +26,16 @@ module FlavourSaver
         r.join ''
       end
 
-      def if(truthy)
-        truthy = false if truthy.respond_to?(:size) && (truthy.size == 0)
-        truthy = false if truthy.respond_to?(:zero?) && truthy.zero?
-
-        if truthy
+      def if(value)
+        if truthy?(value)
           yield.contents
         else
           yield.inverse
         end
       end
 
-      def unless(falsy,&b)
-        self.if(!falsy,&b)
+      def unless(value, &b)
+        self.if(!truthy?(value), &b)
       end
 
       def this
@@ -48,6 +45,16 @@ module FlavourSaver
       def log(message)
         FS.logger.debug("FlavourSaver: #{message}")
         ''
+      end
+
+      private
+
+      # Think of this as a compatability layer to make Ruby conditionals
+      # behave like JavaScript conditionals.
+      def truthy?(value)
+        value = false if value.respond_to?(:size) && (value.size == 0)
+        value = false if value.respond_to?(:zero?) && value.zero?
+        value
       end
     end
 

--- a/spec/acceptance/unless_spec.rb
+++ b/spec/acceptance/unless_spec.rb
@@ -1,0 +1,48 @@
+require 'tilt'
+require 'flavour_saver'
+
+describe 'Fixture: unless.hbs' do
+  subject { Tilt.new(template).render(context).gsub(/[\s\r\n]+/, ' ').strip }
+  let(:context) { Struct.new(:value).new }
+  let(:template) { File.expand_path('../../fixtures/unless.hbs', __FILE__) }
+
+  it "renders the unless block when given false" do
+    context.value = false
+    expect(subject).to eq "The given value is falsy: false."
+  end
+
+  it 'renders the unless block when given nil' do
+    context.value = nil
+    expect(subject).to eq "The given value is falsy: ."
+  end
+
+  it "renders the unless block when given an empty string" do
+    context.value = ""
+    expect(subject).to eq "The given value is falsy: ."
+  end
+
+  it "renders the unless block when given a zero" do
+    context.value = 0
+    expect(subject).to eq "The given value is falsy: 0."
+  end
+
+  it "renders the unless block when given an empty array" do
+    context.value = []
+    expect(subject).to eq "The given value is falsy: []."
+  end
+
+  it "renders the else block when given a string" do
+    context.value = "Alan"
+    expect(subject).to eq "The given value is truthy: Alan."
+  end
+
+  it "renders the else block when given a number greater than zero" do
+    context.value = 1
+    expect(subject).to eq "The given value is truthy: 1."
+  end
+
+  it "renders the else block when given an array that is not empty" do
+    context.value = [1]
+    expect(subject).to eq "The given value is truthy: [1]."
+  end
+end

--- a/spec/fixtures/unless.hbs
+++ b/spec/fixtures/unless.hbs
@@ -1,0 +1,5 @@
+{{#unless value}}
+  The given value is falsy: {{value}}.
+{{else}}
+  The given value is truthy: {{value}}.
+{{/unless}}


### PR DESCRIPTION
The `if` helper has some special logic in it to make conditionals behave more like JavaScript. Previously, that logic didn't apply to the `unless` helper. The `unless` helper was calling `if(!value, &b)` - calling `!value` uses the Ruby conditional logic.

I've pulled out our "JavaScript conditional compatibility" into a method so that both the `if` and `unless` statements can leverage it.

I discovered this divergence with @lucasprag's PR (#54).