### PR TITLE
Fix parse bug for numbers in object path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1]
+
+### Fixed
+
+* Ability to dereference arrays at a specific index (#57)
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flavour_saver (2.0.0)
+    flavour_saver (2.0.1)
       rltk (~> 2.2.0)
       tilt
 

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -128,8 +128,8 @@ module FlavourSaver
       clause('argument_list WHITE hash') { |e0,_,e1| e0 + [e1] }
       clause('hash') { |e| [e] }
     end
-    
-    nonempty_list(:argument_list, [:object_path,:lit, :subexpr], :WHITE)
+
+    nonempty_list(:argument_list, [:object_path, :lit, :subexpr], :WHITE)
 
     production(:lit) do
       clause('string') { |e| e }
@@ -167,7 +167,17 @@ module FlavourSaver
       clause('FWSL') { |_| }
     end
 
-    nonempty_list(:object_path, :object, :object_sep)
+    production(:object_path) do
+      clause('object') { |e| [e] }
+      clause('object_path object_sep object') { |e0,_,e1| e0 + [e1] }
+
+      # Accomodates objects dereferenced with a number like foo.0.text
+      clause('object_path object_sep number_object') { |e0,_,e1| e0 + [e1] }
+    end
+
+    production(:number_object) do
+      clause('NUMBER') { |e| LiteralCallNode.new(e, []) }
+    end
 
     production(:object) do
       clause('AT IDENT') { |_,e| LocalVarNode.new(e) }

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -406,6 +406,21 @@ describe FlavourSaver do
       end
     end
 
+    describe 'array with numeric dereference' do
+      let(:template) {"{{goodbyes.0.text}} cruel {{world}}!"}
+
+      it 'properly inserts the referenced element' do
+        goodbyes = []
+        goodbyes << double(:goodbye)
+        expect(goodbyes[0]).to receive(:text).and_return('goodbye')
+
+        allow(context).to receive(:goodbyes).and_return(goodbyes)
+        allow(context).to receive(:world).and_return('world')
+
+        expect(subject).to eq "goodbye cruel world!"
+      end
+    end
+
     describe 'empty block' do
       let(:template) { "{{#goodbyes}}{{/goodbyes}}cruel {{world}}!" }
 


### PR DESCRIPTION
## 🚨 Bumps version to 2.0.1 🚨 

Though it was never totally supported by FS, you used to be able to dereference an array using a dot accessor.

E.g. to access the 0th element of the array `foo`, you could do:
```hbs
{{foo.0}}
```

There were never any specs for this and you could only access the 0th element because `0` used to be parsed as a literal.

When https://github.com/FlavourSaver/FlavourSaver/pull/53 was merged, `0` started getting parsed as a number and we lost the ability to access the 0th element of an array in this way.

This PR modifies the `object_path` production in the parser so that it can handle numeric dereferences (at all positions, not just `0`).