### PR TITLE
Prep v2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2]
+
+### Fixed
+
+* Deprecation warning for template handler (#59)
+
+### Changed
+
+* Relaxed version constraint on activesupport dependency (#60)
+
 ## [2.0.1]
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flavour_saver (2.0.1)
+    flavour_saver (2.0.2)
       rltk (~> 2.2.0)
       tilt
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 7.0)
+  activesupport (< 8.0)
   flavour_saver!
   rake
   rspec

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'activesupport', '< 7.0'
+  gem.add_development_dependency 'activesupport', '< 8.0'
 
   gem.add_dependency 'rltk', '~> 2.2.0'
   gem.add_dependency 'tilt'

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
* Relaxing constraint on `activesupport`
* Releasing v2.0.2