### PR TITLE
Bump locked dependency versions and drop Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Ruby 3.2.0 added to the test matrix
 
+### Changed
+
+* Bumped locked dependency versions
+
 ## 2.0.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Bumped locked dependency versions
 
+### Removed
+
+* Dropped support for Ruby 2.6
+
 ## 2.0.2
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,38 +8,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.4)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
-    i18n (1.8.11)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.15.0)
+    minitest (5.17.0)
     rake (13.0.6)
     rltk (2.2.1)
       ffi (>= 1.0.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.2)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.3)
-    tilt (2.0.10)
-    tzinfo (2.0.4)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    tilt (2.0.11)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
@@ -51,4 +49,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.2.17
+   2.3.7


### PR DESCRIPTION
### What

* Bumps the locked dependency versions in `Gemfile.lock`
* Drops support for Ruby 2.6 **(breaking change)**

### Why

* ActiveSupport had a CVE
* ActiveSupport v7 doesn't support Ruby 2.6