### PR TITLE
Prepare v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.0.0
+
 ### Added
 
 * Ruby 3.2 and 3.3 added to the test matrix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flavour_saver (2.0.2)
+    flavour_saver (3.0.0)
       rltk (~> 2.2.0)
       tilt
 

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "2.0.2"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
### What

* Bump gem version to 3.0.0 in preparation for release

### Why

* Cutting a new major version because we dropped support for Ruby 2.6.
* Also includes the bug fix from #63 - thanks @flexoid 🥳