### PR TITLE
Drop Ruby 2.6 support, Pin RLTK & Tilt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Ruby 3.2 and 3.3 added to the test matrix
+* Ruby 3.2, 3.3, and 3.4 added to the test matrix
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,33 +2,36 @@ PATH
   remote: .
   specs:
     flavour_saver (2.0.2)
-      rltk (~> 2.2.0)
-      tilt
+      rltk (< 3.0)
+      tilt (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.2)
+    activesupport (7.2.2.1)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     base64 (0.2.0)
-    bigdecimal (3.1.7)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     diff-lcs (1.5.1)
     drb (2.2.1)
-    ffi (1.16.3)
-    i18n (1.14.4)
+    ffi (1.17.1)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    minitest (5.22.3)
-    mutex_m (0.2.0)
+    logger (1.6.5)
+    minitest (5.25.4)
     rake (13.2.1)
     rltk (2.2.1)
       ffi (>= 1.0.0)
@@ -36,16 +39,17 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
-    tilt (2.3.0)
+    rspec-support (3.13.2)
+    securerandom (0.4.1)
+    tilt (2.6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    securerandom (0.4.1)
+    securerandom (0.3.2)
     tilt (2.6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.1)
+    activesupport (7.1.5.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
       securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
+      tzinfo (~> 2.0)
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -32,6 +33,7 @@ GEM
       concurrent-ruby (~> 1.0)
     logger (1.6.5)
     minitest (5.25.4)
+    mutex_m (0.3.0)
     rake (13.2.1)
     rltk (2.2.1)
       ffi (>= 1.0.0)
@@ -57,7 +59,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 8.0)
+  activesupport (< 7.2)
   flavour_saver!
   rake
   rspec

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "activesupport", "< 8.0"
+  gem.add_development_dependency "activesupport", "< 7.2"
 
   gem.add_dependency "rltk", "< 3.0"
   gem.add_dependency "tilt", "~> 2.6"

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FlavourSaver::VERSION
 
-  gem.required_ruby_version = ">= 2.6.0"
+  gem.required_ruby_version = ">= 2.7.0"
 
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'activesupport', '< 8.0'
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "activesupport", "< 8.0"
 
-  gem.add_dependency 'rltk', '~> 2.2.0'
-  gem.add_dependency 'tilt'
+  gem.add_dependency "rltk", "< 3.0"
+  gem.add_dependency "tilt", "~> 2.6"
 end


### PR DESCRIPTION
### What

* Drop support for Ruby 2.6
* Pin RLTK to `< 3.0` since 3.0 seems to [have an unresolved bug](https://github.com/chriswailes/RLTK/issues/63)
* Add Ruby 3.4.1 to the test matrix
* Bump a few dependencies