### PR TITLE
Prepare for release of version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.0.0
+
 ### Added
 
 * Ruby 3.2, 3.3, and 3.4 added to the test matrix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flavour_saver (2.0.2)
+    flavour_saver (3.0.0)
       rltk (< 3.0)
       tilt (~> 2.6)
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@
 ![Build Status](https://github.com/FlavourSaver/FlavourSaver/actions/workflows/ci.yml/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/89a99bec5bbf49359081/maintainability)](https://codeclimate.com/github/FlavourSaver/FlavourSaver/maintainability)
 
-## WAT?
-
-FlavourSaver is a ruby-based implementation of the [Handlebars.js](http://handlebarsjs.com)
+FlavourSaver is a Ruby-based implementation of the [Handlebars.js](http://handlebarsjs.com)
 templating language. FlavourSaver supports Handlebars template rendering natively on
 Rails and on other frameworks (such as Sinatra) via Tilt.
 
 Please use it, break it, and send issues/PR's for improvement.
+
+## Status
+
+This project is currently in maintenance mode. Here's what this means:
+
+* The maintainers of this project are not actively developing new features
+* Issues and pull requests are still welcome
+* New versions of the gem will be released as changes are merged
 
 ## License
 
@@ -41,7 +47,7 @@ FlavourSaver provides an interface to the amazing
 should work with anything that has Tilt support (Sinatra, etc) and has a
 native Rails template handler.
 
-## Status
+## Features
 
 FlavourSaver is in its infancy, your pull requests are greatly appreciated.
 

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "2.0.2"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
### What

* Bump gem version to 3.0.0 in preparation for release

### Why

* Cutting a new major version because we dropped support for Ruby 2.6
* Also includes the bug fix from #63 - thanks @flexoid 🥳